### PR TITLE
Add support for OnlyKey

### DIFF
--- a/app/src/main/java/net/pp3345/ykdroid/ConnectionManager.java
+++ b/app/src/main/java/net/pp3345/ykdroid/ConnectionManager.java
@@ -143,7 +143,7 @@ class ConnectionManager extends BroadcastReceiver implements Application.Activit
 		assert usbManager != null;
 
 		for (final UsbDevice device : usbManager.getDeviceList().values()) {
-			if (device.getVendorId() == UsbYubiKey.YUBICO_USB_VENDOR_ID)
+			if (UsbYubiKey.Type.isDeviceKnown(device))
 				return true;
 		}
 
@@ -162,7 +162,7 @@ class ConnectionManager extends BroadcastReceiver implements Application.Activit
 				this.requestPermission((UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE));
 				break;
 			case UsbManager.ACTION_USB_DEVICE_DETACHED:
-				if (((UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)).getVendorId() == UsbYubiKey.YUBICO_USB_VENDOR_ID) {
+				if (UsbYubiKey.Type.isDeviceKnown(((UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)))) {
 					this.activity.unregisterReceiver(this);
 					this.unplugReceiver.onYubiKeyUnplugged();
 					this.unplugReceiver = null;
@@ -202,7 +202,7 @@ class ConnectionManager extends BroadcastReceiver implements Application.Activit
 	private void requestPermission(final UsbDevice device) {
 		final UsbManager usbManager = (UsbManager) this.activity.getSystemService(Context.USB_SERVICE);
 
-		if (device.getVendorId() != UsbYubiKey.YUBICO_USB_VENDOR_ID)
+		if (!UsbYubiKey.Type.isDeviceKnown(device))
 			return;
 
 		assert usbManager != null;

--- a/app/src/main/java/net/pp3345/ykdroid/yubikey/UsbYubiKey.java
+++ b/app/src/main/java/net/pp3345/ykdroid/yubikey/UsbYubiKey.java
@@ -58,9 +58,11 @@ public class UsbYubiKey implements YubiKey {
 
 		PLUS_U2F_OTP(YUBICO_USB_VENDOR_ID, 0x0410, "YubiKey Plus", "OTP and U2F"),
 
+		YK_UNKNOWN(YUBICO_USB_VENDOR_ID, -0x1, "Unknown YubiKey", ""),
+
 		ONLYKEY(0x1d50, 0x60fc, "OnlyKey", ""),
 
-		UNKNOWN(-0x1, -0x1, "Unknown YubiKey", "");
+		UNKNOWN(-0x1, -0x1, "Unknown Device", "");
 
 		private final int    vendorID;
 		private final int    productID;
@@ -113,10 +115,11 @@ public class UsbYubiKey implements YubiKey {
 		public static Type lookupDeviceType(final UsbDevice device) {
 			for (final Type type : Type.values()) {
 				if (type.getVendorID() == device.getVendorId() &&
-						type.getProductID() == device.getProductId()) {
+						(type.getProductID() == device.getProductId() || type.getProductID() == -0x1)) {
 					return type;
 				}
 			}
+
 			return Type.UNKNOWN;
 		}
 


### PR DESCRIPTION
This PR adds support for the OnlyKey USB token (https://onlykey.io/), which is compatible with YubiKey. 

Tested and working with Keepass2Android and HMAC-SHA1 on my Xiaomi Mi 9T with LineageOS 17.1 (Android 10).